### PR TITLE
docs: use repository instead of homepage in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "enjo"
 description = "Minimalist workspace assistant."
 authors = ["Konstantin Zhigaylo <zero@kostyazero.com>"]
-homepage = "https://github.com/kostya-zero/enjo"
+repository = "https://github.com/kostya-zero/enjo"
 keywords = ["workspace"]
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.